### PR TITLE
Fix settings_reset build by gating init priority Kconfig

### DIFF
--- a/src/Kconfig
+++ b/src/Kconfig
@@ -14,4 +14,5 @@ config ZMK_INPUT_PROCESSOR_ACCELERATION
 
 config INPUT_PROCESSOR_ACCELERATION_INIT_PRIORITY
     int "Input processor acceleration initialization priority"
+    depends on ZMK_INPUT_PROCESSOR_ACCELERATION
     default INPUT_INIT_PRIORITY


### PR DESCRIPTION
## Summary
- make the acceleration init priority Kconfig option depend on the module being enabled to avoid undefined defaults

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691387506b3483218fa7dd5191ef1696)